### PR TITLE
utf8 as text

### DIFF
--- a/apidoc/defs/rune.yaml
+++ b/apidoc/defs/rune.yaml
@@ -1,9 +1,9 @@
 Rune:
   type: object
   properties:
-    utf8:
+    text:
       type: string
-      descript: string with same color
+      descript: string (in json-unicode) with same color
     color0:
       '$ref': '#/definitions/Color'
     color1:

--- a/types/rune.go
+++ b/types/rune.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Rune struct {
-	Utf8   string `json:"utf8" bson:"utf8"` //utf8-string
+	Utf8   string `json:"text" bson:"utf8"` //utf8-string
 	Big5   []byte `json:"-" bson:"big5"`    //big5-bytes, store in db for debugging.
 	Color0 Color  `json:"color0" bson:"color0"`
 	Color1 Color  `json:"color1" bson:"color1"`


### PR DESCRIPTION
after discussing with joe-su～
Found that text is a more appropriate naming for the Rune-utf8 in json.
(json use \uxxxx to represent unicode)

bson defines that string is utf-8 encoding. It's ok to specify bson as utf8.

http://bsonspec.org/spec.html
