### PR TITLE
chore: add testing command in Makefile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,10 +46,5 @@ jobs:
     - name: Testing
       run: make test
 
-    - name: Testing with noqueue tag
-      run: make test
-      env:
-        TAGS: noqueue
-
     - name: Upload coverage report
       uses: codecov/codecov-action@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,8 @@ jobs:
 
     - name: Testing
       run: make test
+      env:
+        TAGS: noqueue
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Build
       run: make
 
+    - name: TestQueueCommentDBCS
+      run: go test -v ./... -run TestQueueCommentDBCS -tags queue
+
     - name: Testing
       run: make test
       env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,21 +41,15 @@ jobs:
         version: v1.41.1
 
     - name: Build
-      run: go build -v ./...
+      run: make
 
-    - name: TestQueueCommentDBCS
-      run: go test -v ./... -run TestQueueCommentDBCS
+    - name: Testing
+      run: make test
 
-    - name: Test
-      run: go test -v ./... -tags noqueue
-
-    - name: Coverage-queue
-      run: go test ./... -run TestQueueCommentDBCS -cover
-
-    - name: Coverage
-      run: go test ./... -tags noqueue -cover -coverprofile cover.out
+    - name: Testing with noqueue tag
+      run: make test
+      env:
+        TAGS: noqueue
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
-      with:
-        file: cover.out

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /docker/docker_compose.env
 /swagger
 /bin/
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOFMT ?= gofumpt -l -s
 GO ?= go
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GOFILES := $(shell find . -name "*.go")
-TAGS ?=
+TAGS ?= ""
 GOPATH ?= $(shell $(GO) env GOPATH)
 
 ifneq ($(shell uname), Darwin)
@@ -30,3 +30,7 @@ build: $(SERVICE)
 
 $(SERVICE): $(GOFILES)
 	$(GO) build -v -tags '$(TAGS)' -ldflags '$(EXTLDFLAGS)-s -w $(LDFLAGS)' -o bin/$@ .
+
+.PHONY: test
+test:
+	$(GO) test -v -cover -tags $(TAGS) -coverprofile coverage.txt ./... && echo "\n==>\033[32m Ok\033[m\n" || exit 1

--- a/queue/comment_queue_test.go
+++ b/queue/comment_queue_test.go
@@ -1,5 +1,3 @@
-// +build !noqueue
-
 package queue
 
 import (

--- a/queue/comment_queue_test.go
+++ b/queue/comment_queue_test.go
@@ -1,3 +1,5 @@
+// +build queue
+
 package queue
 
 import (

--- a/queue/init_test.go
+++ b/queue/init_test.go
@@ -1,5 +1,3 @@
-// +build !noqueue
-
 package queue
 
 import "testing"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-gotest ./... -coverprofile cover.out -tags noqueue
-
+gotest ./... -coverprofile cover.out
 go tool cover -html=cover.out

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 go build ./...
-gotest -v ./... -p 1 -run TestQueueCommentDBCS
-gotest -v ./... -p 1 -cover -tags noqueue
+gotest -v ./... -p 1 -run TestQueueCommentDBCS -tags queue
+gotest -v ./... -p 1 -cover


### PR DESCRIPTION
Simplify the go command in GitHub Actions. @chhsiao1981 I don't know why TestQueueCommentDBCS can't be tested in integration testing so I keep the test `TestQueueCommentDBCS` command.

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>

