### PR TITLE
Fix wrong type of subject_type

### DIFF
--- a/apidoc/defs/article_summary_core.yaml
+++ b/apidoc/defs/article_summary_core.yaml
@@ -40,5 +40,5 @@ idx:
 rank:
   type: number
 subject_type:
-  type: string
+  type: number
   description: https://github.com/Ptt-official-app/go-pttbbs/blob/v0.16.2/ptttype/subject_type.go


### PR DESCRIPTION
## 這個 PR 的目的 / Purpose of this PR
As title.  
The `subject_type` in this [API](https://api.devptt.site:5000/#/article/get_api_articles_popular).   
Should be `number` not `string`.   

```
{
  "list": [
    {
      "bid": "WhoAmI",
      "aid": "M.1234567890.A.123",
      "deleted": false,
      "create_time": 1234567890,
      "modified": 1234567888,
      "recommend": 8,
      "n_comments": 0,
      "owner": "okcool",
      "title": "[問題]然後呢？～",
      "money": 5,
      "class": "問題",
      "mode": 0,
      "url": "http://localhost/bbs/test/M.1234567890.A.123",
      "read": false,
      "idx": "",
      "rank": 0,
      "subject_type": 0 <= here 
    }]
}
```
## 相關的 issue / Related Issues
