### PR TITLE
enhance utf-8 content

### DIFF
--- a/dbcs/dbcs.go
+++ b/dbcs/dbcs.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/Ptt-official-app/go-openbbsmiddleware/types"
-	"github.com/sirupsen/logrus"
 )
 
 func Utf8ToDBCS(utf8 [][]*types.Rune) (dbcsBytes [][]byte) {
@@ -341,23 +340,23 @@ func dbcsToBig5PurifyColor(dbcs []byte) []byte {
 	return purified
 }
 
-func dbcsIntegrateColor(color0 types.Color, color1 types.Color) (color types.Color) {
-	if color1.IsReset {
-		color1.IsReset = false
-		return color1
+func dbcsIntegrateColor(origColor types.Color, newColor types.Color) (color types.Color) {
+	if newColor.IsReset {
+		newColor.IsReset = false
+		return newColor
 	}
 
-	color = color0
-	if color1.Foreground != types.COLOR_INVALID {
-		color.Foreground = color1.Foreground
+	color = origColor
+	if newColor.Foreground != types.COLOR_INVALID {
+		color.Foreground = newColor.Foreground
 	}
-	if color1.Background != types.COLOR_INVALID {
-		color.Background = color1.Background
+	if newColor.Background != types.COLOR_INVALID {
+		color.Background = newColor.Background
 	}
-	if color1.Highlight {
+	if newColor.Highlight {
 		color.Highlight = true
 	}
-	if color1.Blink {
+	if newColor.Blink {
 		color.Blink = true
 	}
 
@@ -392,7 +391,6 @@ func dbcsParseColor(dbcs []byte) (color types.Color, nBytes int) {
 		}
 
 		colorCodeList := bytes.Split(p_dbcs[2:idxM], []byte{';'})
-		logrus.Infof("dbcsParseColor: p_dbcs: %v colorCodeList: %v", string(p_dbcs[2:idxM]), colorCodeList)
 		for idx, each := range colorCodeList {
 			if idx == 0 && len(each) == 0 { // reset
 				color = types.DefaultColor

--- a/dbcs/dbcs_utf8.go
+++ b/dbcs/dbcs_utf8.go
@@ -188,6 +188,13 @@ func dbcsToUtf8PerLineParseColor(colorDBCS string, origColor types.Color) (color
 	theList := strings.Split(colorDBCS, ";")
 	isAlreadyForeground := false
 	for idx, each := range theList {
+		if idx == 0 && len(each) == 0 { // reset
+			// no need to do color.IsReset
+			// because dbcsIntegrateColor always set IsReset as false
+			color = types.DefaultColor
+			continue
+		}
+
 		eachNum, err := strconv.Atoi(each)
 		if err != nil {
 			continue

--- a/dbcs/dbcs_utf8_test.go
+++ b/dbcs/dbcs_utf8_test.go
@@ -124,6 +124,11 @@ func Test_dbcsToUtf8PerLineParseColor(t *testing.T) {
 			expectedColor: types.Color{Foreground: types.COLOR_FOREGROUND_RED, Background: types.COLOR_BACKGROUND_WHITE},
 		},
 		{
+			name:          "with \x1b[;m",
+			args:          args{colorDBCS: "\x1b[;31;47m", origColor: types.Color{Foreground: types.COLOR_FOREGROUND_BLUE, Background: types.COLOR_BACKGROUND_CYAN, Highlight: true, Blink: true}},
+			expectedColor: types.Color{Foreground: types.COLOR_FOREGROUND_RED, Background: types.COLOR_BACKGROUND_WHITE},
+		},
+		{
 			name:          "with \x1b[m",
 			args:          args{colorDBCS: "\x1b[m", origColor: types.Color{Foreground: types.COLOR_FOREGROUND_BLUE, Background: types.COLOR_BACKGROUND_CYAN, Highlight: true, Blink: true}},
 			expectedColor: types.Color{Foreground: types.COLOR_FOREGROUND_WHITE, Background: types.COLOR_BACKGROUND_BLACK},

--- a/dbcs/testutf88_test.go
+++ b/dbcs/testutf88_test.go
@@ -1826,8 +1826,8 @@ func initTestUtf88() {
 			{
 				Utf8:    "╭",
 				DBCSStr: "\x1b[;30;40m\x1b[147m╭",
-				Color0:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_BLACK, Highlight: true},
-				Color1:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_WHITE, Highlight: true},
+				Color0:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_BLACK},
+				Color1:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_WHITE},
 			},
 			{
 				Utf8:    "◣",
@@ -1856,8 +1856,8 @@ func initTestUtf88() {
 			{
 				Utf8:    "ν",
 				DBCSStr: "\x1b[;30;47mν",
-				Color0:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_WHITE, Highlight: true},
-				Color1:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_WHITE, Highlight: true},
+				Color0:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_WHITE},
+				Color1:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_WHITE},
 			},
 			{
 				Utf8:    "y",
@@ -2703,8 +2703,8 @@ func initTestUtf88() {
 			{
 				Utf8:    "0rz.net/b41dH",
 				DBCSStr: "\x1b[;5;30m0rz.net/b41dH",
-				Color0:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_BLACK, Highlight: true, Blink: true},
-				Color1:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_BLACK, Highlight: true, Blink: true},
+				Color0:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_BLACK, Blink: true},
+				Color1:  types.Color{Foreground: types.COLOR_FOREGROUND_BLACK, Background: types.COLOR_BACKGROUND_BLACK, Blink: true},
 			},
 			{
 				Utf8:    "",


### PR DESCRIPTION
## 這個 PR 的目的 / Purpose of this PR

similar to #435, but for utf-8 content from boardd
`[;34;40m` is considered as resetting color first before setting fg-blue/bg-black.

## 相關的 issue / Related Issues
