### PR TITLE
add subject-type in article-detail-summary

### DIFF
--- a/api/article_utils.go
+++ b/api/article_utils.go
@@ -449,6 +449,7 @@ func tryGetArticleDetailSummary(userID bbs.UUserID, boardID bbs.BBoardID, articl
 		Class:        articleSummary_db.Class,
 		Filemode:     articleSummary_db.Filemode,
 		UpdateNanoTS: articleSummary_db.UpdateNanoTS,
+		SubjectType:  articleSummary_db.SubjectType,
 	}
 
 	return articleDetailSummary, 200, nil

--- a/api/get_article_blocks.go
+++ b/api/get_article_blocks.go
@@ -24,17 +24,18 @@ type GetArticleBlocksPath struct {
 type GetArticleBlocksResult struct {
 	Content [][]*types.Rune `json:"content,omitempty"`
 
-	IsDeleted  bool             `json:"deleted,omitempty"`     //
-	CreateTime types.Time8      `json:"create_time,omitempty"` //
-	MTime      types.Time8      `json:"modified,omitempty"`    //
-	Recommend  int              `json:"recommend,omitempty"`   //
-	NComments  int              `json:"n_comments,omitempty"`  //
-	Owner      bbs.UUserID      `json:"owner,omitempty"`       //
-	Nickname   string           `json:"nickname,omitempty"`
-	Title      string           `json:"title,omitempty"` //
-	Money      int              `json:"money,omitempty"` //
-	Class      string           `json:"class,omitempty"` // can be: R: 轉, [class]
-	Filemode   ptttype.FileMode `json:"mode,omitempty"`  //
+	IsDeleted   bool                `json:"deleted,omitempty"`     //
+	CreateTime  types.Time8         `json:"create_time,omitempty"` //
+	MTime       types.Time8         `json:"modified,omitempty"`    //
+	Recommend   int                 `json:"recommend,omitempty"`   //
+	NComments   int                 `json:"n_comments,omitempty"`  //
+	Owner       bbs.UUserID         `json:"owner,omitempty"`       //
+	Nickname    string              `json:"nickname,omitempty"`
+	Title       string              `json:"title,omitempty"` //
+	Money       int                 `json:"money,omitempty"` //
+	Class       string              `json:"class,omitempty"` // can be: R: 轉, [class]
+	Filemode    ptttype.FileMode    `json:"mode,omitempty"`  //
+	SubjectType ptttype.SubjectType `json:"subject_type"`
 
 	IP   string `json:"ip,omitempty"`
 	Host string `json:"host,omitempty"` // ip 的中文呈現, 外國則為國家.
@@ -130,6 +131,7 @@ func GetArticleBlocks(remoteAddr string, user *UserInfo, params interface{}, pat
 		ret.Host = articleDetailSummary.Host
 		ret.BBS = articleDetailSummary.BBS
 		ret.Rank = articleDetailSummary.Rank
+		ret.SubjectType = articleDetailSummary.SubjectType
 	}
 
 	return ret, 200, nil

--- a/api/get_article_detail.go
+++ b/api/get_article_detail.go
@@ -33,6 +33,8 @@ type GetArticleDetailResult struct {
 	Class      string              `json:"class"` // can be: R: 轉, [class]
 	Filemode   ptttype.FileMode    `json:"mode"`  //
 
+	SubjectType ptttype.SubjectType `json:"subject_type"`
+
 	URL  string `json:"url"`  //
 	Read bool   `json:"read"` //
 
@@ -117,6 +119,7 @@ func GetArticleDetail(remoteAddr string, user *UserInfo, params interface{}, pat
 		Host:          host,
 		BBS:           bbs,
 		Rank:          articleDetailSummary.Rank,
+		SubjectType:   articleDetailSummary.SubjectType,
 
 		TokenUser: userID,
 	}

--- a/schema/article_detail_summary.go
+++ b/schema/article_detail_summary.go
@@ -47,6 +47,8 @@ type ArticleDetailSummary struct {
 	RankUpdateNanoTS types.NanoTS `bson:"rank_update_nano_ts"`
 
 	Idx string `bson:"pttidx"`
+
+	SubjectType ptttype.SubjectType `bson:"subject_type"`
 }
 
 var (

--- a/schema/lock_test.go
+++ b/schema/lock_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -43,8 +44,12 @@ func TestTryLock(t *testing.T) {
 			sleepTS: 4,
 		},
 	}
+
+	var wg sync.WaitGroup // to sequentially exec the test.
 	for _, tt := range tests {
+		wg.Add(1)
 		t.Run(tt.name, func(t *testing.T) {
+			defer wg.Done()
 			if tt.sleepTS > 0 {
 				time.Sleep(time.Duration(tt.sleepTS) * time.Second)
 			}
@@ -61,5 +66,6 @@ func TestTryLock(t *testing.T) {
 				t.Errorf("TryLock: e: %v expected: %v", err, tt.expectedErr)
 			}
 		})
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
1. include SubjectType in schema.ArticleDetailSummary
2. include SubjectType in api.GetArticleDetailResult
3. include SubjectType in api.GetArticleBlocksResult

## 這個 PR 的目的 / Purpose of this PR

## 相關的 issue / Related Issues
